### PR TITLE
Remove tag settings for docker/metadata-action

### DIFF
--- a/.github/workflows/build_image.yml
+++ b/.github/workflows/build_image.yml
@@ -31,11 +31,6 @@ jobs:
       uses: docker/metadata-action@v3
       with:
         images: ${{ env.CONTAINER_REGISTRY }}/${{ github.repository }}
-        tags: |
-          type=semver,pattern=v{{version}}
-          type=semver,pattern=v{{major}}.{{minor}}
-          type=semver,pattern=v{{major}}
-          type=sha
 
     - name: Login to GitHub Container Registry
       uses: docker/login-action@v1


### PR DESCRIPTION
I needed tags whose name is branch name or tag name, and this was accomplished by [default setting](https://github.com/docker/metadata-action#tags-input).